### PR TITLE
Edit node texts

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["ZachPage"]
 license = ""
 repository = ""
 edition = "2021"
+exclude = ["/test/data/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["ui"],
+  "exclude": ["src-tauri/test/data*"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/ui/canvas/Canvas.css
+++ b/ui/canvas/Canvas.css
@@ -6,3 +6,7 @@
   cursor: grab;
   background-color: lightgrey
 }
+
+#NodeEditTextBox {
+  background-color: gray
+}

--- a/ui/canvas/CanvasElems.ts
+++ b/ui/canvas/CanvasElems.ts
@@ -11,7 +11,6 @@ export class CanvasElement {
 }
 
 // Will hold information regarding decisions / pros / cons / etc. 
-// - Technically a CanvasElement, but not since nothing to display
 export class Node {
   static collectionTitle: string = "";
   static collection: Node[] = []

--- a/ui/canvas/Render.ts
+++ b/ui/canvas/Render.ts
@@ -49,6 +49,7 @@ export class Renderer {
     });
   }
 
+  // Render functions
   renderNodes(nodes : fromRust.Nodes) {
     this.cy.remove(this.cy.nodes());
     this.cy.remove(this.cy.edges());
@@ -70,5 +71,13 @@ export class Renderer {
       const childNodeId = notNull(newCanvasNode.cyNode.data().id);
       this.cy.add({group: 'edges', data: {source: parentNodeId, target: childNodeId}})
     });
+  }
+
+  // Public interaction functions
+  updateNodeData(node: fromRust.Node, attribute: string, value: any) {
+    // Edit the node text through the cy API to update the graph, then ensure the rerender doesn't affect the view
+    let cyNode = this.cy.getElementById(node.file_order.toString());
+    cyNode.data(`nodeData.dataNode.${attribute}`, value);
+    this.cy.elements().layout({name: 'dagre', fit: false, centerGraph: false}).run();
   }
 };


### PR DESCRIPTION
Renders a `textarea` over the node with the current text when a user clicks a node, then `ctrl+e`.
Once the text is changed, can press `ctrl+e` again to update the node & the graph layout.
Verified by updating a test file manually.