### PR TITLE
Parse Node type from file & bugfix edit cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ The goals of this project are to:
 ## Encoding Terms / Abbreviations
 To create the decision hierarchy, we'll use an encoding strategy for organization (`<Token>: ...` or `* <Token>: ...`):
 * `D`: Decision
-* `B`: Branch
+* `O`: Option
 * `P`: Pro
 * `C`: Con
 * `N`: Note
 
 ### Mapping Rules
-Decisions can have 1 to many Branches - labeled `B1` / `B2` / etc  
-Branches can become Decisions also - `B/D`  
-Pros / Cons associate with one to many Branches:
-* The association can be opposite - ex. a Pro for `B1` is a con for `B2`
-* This will likely be tracked with tokens like `P1B1C1B2`  
+Decisions can have 1 to many Options - labeled `O1` / `O2` / etc  
+Options can become Decisions also - `O/D`  
+Pros / Cons associate with one to many Options:
+* The association can be opposite - ex. a Pro for `O1` is a con for `O2`
+* This will likely be tracked with tokens like `P1O1C1O2`  
 
 Notes can be associated with one to many of any entity  
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -28,22 +28,26 @@ Here is a list of in order milestones to guide this project:
 * Start parsing bullet points - serialize the data to send to UI - done
 * Display a new node per bullet point - done
 * Integrate cytoscape (Use to layout graph, rebind current pan / zoom motions) - done
-* Figure out layout settings to have: Ds left -> right, B / P / C top to bottom - done?
+* Figure out layout settings to have: Ds left -> right, O / P / C top to bottom - done?
 * Display an error pop up - done
 * Skeleton layout of app toolbars - done
 * Add a quick way to allow a user to open a file - done
-* Ctrl+S to reserialize the UI content & write it back out to file (should match original)
-* Ctrl+click to edit a nodes text - should be able to save & update the file
-* Read a basic encoded file in Rust to get the D B P Cs - display type (see README.md)
-* Add color codes - Pro (green), Con (red), Decision (light orange) Branch (light blue), Notes (light yellow)
-* Context menu for canvas - create Decision - write update to file
-* Context menu for node - create B / P / C
-  * Make hot-keys to create elements
+* Ctrl+S to reserialize the UI content & write it back out to file (should match original) - done
+* Ctrl+click to edit a nodes text - should be able to save & update the file - done
+* Read a basic encoded file in Rust to get the D O P Cs - display type (see README.md) - done
+* Add color codes - Pro (green), Con (red), Decision (light orange) Option (light blue), Notes (light yellow)
+* Move selection with h j k l - manage with new MovementHandler
+* Creation - shortcut keys only:
+  * ctrl+c to enter creation state, then either d o p c n - manage with new CreationHandler
+  * None selected - can create a D - add to graph and allow typing - write update to file
+  * Node selected:
+    * D - can create D or O - send error if press something else
+    * O - can create D, P, C
 * Side menu to show hot-key / color coding help
 * Figure out Pro to one branch but a Con to another - make color light brown, make lines green / red (pro/con)
 * Make relationships collapsible
 * Make nodes collapsible (only show partial text)
-* Filter what is being viewed - Ds, Bs, Ps, Cs, Ns - change through view modal
+* Filter what is being viewed - Ds, Os, Ps, Cs, Ns - change through view modal
 * Create color scheme to make UI look better
 * Figure out bundling
 * Replace quick file opener with a file explorer in the left toolbar

--- a/src-tauri/src/mdt/file_parse.rs
+++ b/src-tauri/src/mdt/file_parse.rs
@@ -1,13 +1,11 @@
 pub mod file_parse {
 
-use super::structs::{Node, Nodes};
+use super::bullet_file_parser::BulletFileParser;
+use super::structs::Nodes;
 use std::path::PathBuf;
 use std::error::Error;
 use std::fs::read_to_string;
 use lazy_static::lazy_static;
-use regex::Regex;
-use std::collections::VecDeque;
-use std::convert::TryFrom;
 
 // TODO - preserve from original file or make configurable
 pub const NUM_SPACES_PER_LEVEL: u32 = 2;
@@ -15,7 +13,6 @@ pub const NUM_SPACES_PER_LEVEL: u32 = 2;
 // For non-const statics
 lazy_static! {
   pub static ref DATA_DIR: PathBuf = PathBuf::from(format!("{top_dir}/test/data", top_dir=env!("CARGO_MANIFEST_DIR")));
-  pub static ref START_NODE_BEGIN_REGEX: Regex = Regex::new(r"\s*\* ").unwrap();
 }
 
 /// Top level function called from the front end
@@ -29,7 +26,7 @@ pub fn parse_file(file_path: PathBuf) -> Result<Nodes, Box<dyn Error>> {
 
   let mut nodes = Nodes{title: first_line.to_string(), ..Default::default()};
 
-  let mut parser = BulletFileParser{..Default::default()};
+  let mut parser = BulletFileParser::new();
   for line in lines {
     match parser.handle_line(&line.to_string()) {
       Err(e) => return Err(e.into()),
@@ -37,72 +34,6 @@ pub fn parse_file(file_path: PathBuf) -> Result<Nodes, Box<dyn Error>> {
     };
   }
   return Ok(nodes);
-}
-
-/// Last node read that may be a parent to the current node
-#[derive(Copy, Clone)]
-struct PotentialParent { level: u32, idx: u32 } 
-
-/// Parses bullet point files
-#[derive(Default)]
-struct BulletFileParser
-{
-    file_order_cnt : u32,
-    prev_parsed_text: Option<String>,
-    parent_q: VecDeque<PotentialParent>,
-}
-
-/// Parses file with bullet points into node children
-impl BulletFileParser {
-  /// Push into to queue to potentially use as parent node later
-  pub fn add_curr_as_pot_parent(&mut self, level: u32) {
-    self.parent_q.push_back(PotentialParent{level: level, idx: self.file_order_cnt});
-  }
-
-  /// Create nodes with their file order & tie them to their parent nodes using the indent level
-  pub fn create_node(&mut self, text: &String, indent_level: u32) -> Node {
-    let mut new_node = Node{text: text.to_string(), level: indent_level, 
-                        file_order: self.file_order_cnt, ..Default::default()};
-    // A file will have the nodes in DFS order. So can pop through the potential parent queue until we find our current
-    // parent. So if its not the current nodes parent, can remove it since it wont be future node's parent either.
-    while !self.parent_q.is_empty() {
-      if let Some(ref pot_parent) = self.parent_q.back() {
-        if pot_parent.level < new_node.level {
-          new_node.parent_idxs.push(pot_parent.idx);
-          self.add_curr_as_pot_parent(new_node.level);
-          break;
-        } else {
-          self.parent_q.pop_back();
-        }
-      }
-    }
-    if self.parent_q.is_empty() {
-      self.add_curr_as_pot_parent(new_node.level);
-    }
-    self.file_order_cnt += 1;
-    return new_node;
-  }
-
-  /// Parse a file line & create a node if its a new bullet point
-  pub fn handle_line(&mut self, line: &String) -> Result<Option<Node>, String> {
-    if line.is_empty() { return Ok(None); }
-    let start_of_node_match = START_NODE_BEGIN_REGEX.find(line);
-    if self.prev_parsed_text.is_none() {
-      if start_of_node_match.is_none() { 
-        return Ok(Some(self.create_node(line, 0))); //< Parent node
-      } else {
-        let first_bullet_idx = line.find("*").unwrap();
-        let expected_num_spaces = usize::try_from(NUM_SPACES_PER_LEVEL).map_err(|err| err.to_string())?;
-        let mut indent_level = u32::try_from(first_bullet_idx / expected_num_spaces).map_err(|err| err.to_string())?;
-        indent_level += 1;
-        return Ok(Some(self.create_node(&(&line[first_bullet_idx+2..]).to_string(), indent_level)));
-      }
-    } else {
-      // TODO - implement multi-line bullets
-
-    }
-    return Ok(None);
-  }
 }
 
 #[cfg(test)]
@@ -115,63 +46,6 @@ mod tests {
     assert!(node_res.is_err());
     if let Err(err) = node_res {
       assert!(err.to_string().contains("md-decision-trees"));
-    }
-  }
-
-  fn vecs_match<T: Eq>(a: &Vec<T>, b: &Vec<T>) -> bool {
-    if a.len() != b.len() { return false; }
-    let num_matching = a.iter().zip(b.iter()).filter(|&(a,b)| a == b).count();
-    return num_matching == a.len();
-  }
-
-  #[test]
-  fn test_bullet_parsing() {
-    let node_res = parse_file(DATA_DIR.join("01_bullets.md"));
-    assert!(node_res.is_ok());
-    if let Ok(nodes) = node_res {
-      assert!(nodes.nodes.len() == 10); //< Should match how many nodes are in the file
-
-      // Get nodes for later testing & verify their names
-      let get_node_with_name = |idx: u32, name: &str| -> &Node { 
-        let node_at_idx = &nodes.nodes[idx];
-        assert!(node_at_idx.text == name);
-        return node_at_idx;
-      };
-      let p1 = get_node_with_name(0, "Parent1");
-      let c11 = get_node_with_name(1, "Child1.1");
-      let c12 = get_node_with_name(2, "Child1.2");
-      let c121 = get_node_with_name(3, "Child1.2.1");
-      let c1211 = get_node_with_name(4, "Child1.2.1.1");
-      let c122 = get_node_with_name(5, "Child1.2.2");
-      let c13 = get_node_with_name(6, "Child1.3");
-      let p2 = get_node_with_name(7, "Parent2");
-      let c21 = get_node_with_name(8, "Child2.1");
-
-      // Verify file order
-      assert!(p1.file_order == 0);
-      assert!(c11.file_order == 1);
-      assert!(c12.file_order == 2);
-      assert!(c121.file_order == 3);
-      assert!(p2.file_order == 7);
-
-      // Verify leveling
-      assert!(p1.level == 0);
-      assert!(c11.level == 1);
-      assert!(c12.level == 1);
-      assert!(c121.level == 2);
-      assert!(p2.level == 0);
-      assert!(c21.level == 1);
-
-      // Verify parent index handling
-      assert!(p1.parent_idxs.is_empty());
-      assert!(vecs_match(&c11.parent_idxs, &Vec::from([p1.file_order])));
-      assert!(vecs_match(&c12.parent_idxs, &Vec::from([p1.file_order])));
-      assert!(vecs_match(&c121.parent_idxs, &Vec::from([c12.file_order])));
-      assert!(vecs_match(&c1211.parent_idxs, &Vec::from([c121.file_order])));
-      assert!(vecs_match(&c122.parent_idxs, &Vec::from([c12.file_order])));
-      assert!(vecs_match(&c13.parent_idxs, &Vec::from([p1.file_order])));
-      assert!(p2.parent_idxs.is_empty());
-      assert!(vecs_match(&c21.parent_idxs, &Vec::from([p2.file_order])));
     }
   }
 }

--- a/src-tauri/src/mdt/mod.rs
+++ b/src-tauri/src/mdt/mod.rs
@@ -3,3 +3,6 @@ include!("cmds.rs");
 include!("file_parse.rs");
 include!("file_write.rs");
 include!("structs.rs");
+
+// - Parsers
+include!("parsers/bullet_file_parser.rs");

--- a/src-tauri/src/mdt/parsers/bullet_file_parser.rs
+++ b/src-tauri/src/mdt/parsers/bullet_file_parser.rs
@@ -1,0 +1,176 @@
+pub mod bullet_file_parser {
+
+use super::file_parse::{NUM_SPACES_PER_LEVEL};
+use super::structs::{Node, NodeType};
+use std::collections::VecDeque;
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::str::FromStr;
+
+// For non-const statics
+lazy_static! {
+  pub static ref START_NODE_BEGIN_REGEX: Regex = Regex::new(r"\s*\* ").unwrap();
+}
+
+/// Last node read that may be a parent to the current node
+#[derive(Copy, Clone)]
+struct PotentialParent { level: u32, idx: u32 } 
+
+/// Parses bullet point files
+#[derive(Default)]
+pub struct BulletFileParser
+{
+  file_order_cnt : u32,
+  prev_parsed_text: Option<String>,
+  parent_q: VecDeque<PotentialParent>,
+  force_node_type: bool
+}
+
+/// Parses file with bullet points into node children
+impl BulletFileParser {
+  pub fn new() -> BulletFileParser { return BulletFileParser{..Default::default()}; }
+
+  /// Parse a file line & create a node if its a new bullet point
+  pub fn handle_line(&mut self, line: &String) -> Result<Option<Node>, String> {
+    if line.is_empty() { return Ok(None); }
+    let start_of_node_match = START_NODE_BEGIN_REGEX.find(line);
+    if self.prev_parsed_text.is_none() {
+      if start_of_node_match.is_none() { 
+        return Ok(Some(self.create_node(line, 0))); //< Parent node
+      } else {
+        let first_bullet_idx = line.find("*").unwrap();
+        let expected_num_spaces = usize::try_from(NUM_SPACES_PER_LEVEL).map_err(|err| err.to_string())?;
+        let mut indent_level = u32::try_from(first_bullet_idx / expected_num_spaces).map_err(|err| err.to_string())?;
+        indent_level += 1;
+        return Ok(Some(self.create_node(&line[first_bullet_idx+2..], indent_level)));
+      }
+    } else {
+      // TODO - implement multi-line bullets
+
+    }
+    return Ok(None);
+  }
+
+  /// Push into to queue to potentially use as parent node later
+  fn add_curr_as_pot_parent(&mut self, level: u32) {
+    self.parent_q.push_back(PotentialParent{level: level, idx: self.file_order_cnt});
+  }
+
+  /// Create nodes with their file order & tie them to their parent nodes using the indent level
+  fn create_node(&mut self, text: &str, indent_level: u32) -> Node {
+    let mut new_node = Node{level: indent_level, file_order: self.file_order_cnt, ..Default::default()};
+    if let Some((node_type, new_text)) = self.split_node_type_from_string(&text) {
+      new_node.type_is = Some(node_type);
+      new_node.text = new_text;
+    } else {
+      new_node.text = text.to_string();
+    }
+    // A file will have the nodes in DFS order. So can pop through the potential parent queue until we find our current
+    // parent. So if its not the current nodes parent, can remove it since it wont be future node's parent either.
+    while !self.parent_q.is_empty() {
+      if let Some(ref pot_parent) = self.parent_q.back() {
+        if pot_parent.level < new_node.level {
+          new_node.parent_idxs.push(pot_parent.idx);
+          self.add_curr_as_pot_parent(new_node.level);
+          break;
+        } else {
+          self.parent_q.pop_back();
+        }
+      }
+    }
+    if self.parent_q.is_empty() {
+      self.add_curr_as_pot_parent(new_node.level);
+    }
+    self.file_order_cnt += 1;
+    return new_node;
+  }
+
+  /// Parse off optional NodeType and ensure its valid if this is a NodeType file (vs regular bullets)
+  /// TODO - skip this string copy and just make text mut
+  fn split_node_type_from_string(&mut self, text: &str) -> Option<(NodeType, String)> {
+    if let Some(first_colon_idx) = text.find(":") {
+      if let Ok(node_type) = NodeType::from_str(&text[..first_colon_idx]) {
+        self.force_node_type = true;
+        // TODO - make this more robust
+        let colon_and_space_size = 2;
+        return Some((node_type, text[first_colon_idx+colon_and_space_size..].to_string()));
+      }
+    }
+    if self.force_node_type {
+      panic!("Line did not have a NodeType, though previous line did - line missing type: '{}'", text);
+    }
+    return None;
+  }
+
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use super::super::file_parse::{DATA_DIR, parse_file};
+
+  fn vecs_match<T: Eq>(a: &Vec<T>, b: &Vec<T>) -> bool {
+    if a.len() != b.len() { return false; }
+    let num_matching = a.iter().zip(b.iter()).filter(|&(a,b)| a == b).count();
+    return num_matching == a.len();
+  }
+
+  #[test]
+  fn test_bullet_parsing() {
+    let node_res = parse_file(DATA_DIR.join("01_bullets.md"));
+    assert!(node_res.is_ok());
+    if let Ok(nodes) = node_res {
+      assert!(nodes.nodes.len() == 10); //< Should match how many nodes are in the file
+
+      // Get nodes for later testing & verify their names
+      let get_node_with_name = |idx: usize, name: &str| -> &Node { 
+        let node_at_idx = &nodes.nodes[idx];
+        assert!(node_at_idx.text == name);
+        return node_at_idx;
+      };
+      let p1 = get_node_with_name(0, "Parent1");
+      let c11 = get_node_with_name(1, "Child1.1");
+      let c12 = get_node_with_name(2, "Child1.2");
+      let c121 = get_node_with_name(3, "Child1.2.1");
+      let c1211 = get_node_with_name(4, "Child1.2.1.1");
+      let c122 = get_node_with_name(5, "Child1.2.2");
+      let c13 = get_node_with_name(6, "Child1.3");
+      let p2 = get_node_with_name(7, "Parent2");
+      let c21 = get_node_with_name(8, "Child2.1");
+
+      // Verify file order
+      assert!(p1.file_order == 0);
+      assert!(c11.file_order == 1);
+      assert!(c12.file_order == 2);
+      assert!(c121.file_order == 3);
+      assert!(p2.file_order == 7);
+
+      // Verify leveling
+      assert!(p1.level == 0);
+      assert!(c11.level == 1);
+      assert!(c12.level == 1);
+      assert!(c121.level == 2);
+      assert!(p2.level == 0);
+      assert!(c21.level == 1);
+
+      // Verify parent index handling
+      assert!(p1.parent_idxs.is_empty());
+      assert!(vecs_match(&c11.parent_idxs, &Vec::from([p1.file_order])));
+      assert!(vecs_match(&c12.parent_idxs, &Vec::from([p1.file_order])));
+      assert!(vecs_match(&c121.parent_idxs, &Vec::from([c12.file_order])));
+      assert!(vecs_match(&c1211.parent_idxs, &Vec::from([c121.file_order])));
+      assert!(vecs_match(&c122.parent_idxs, &Vec::from([c12.file_order])));
+      assert!(vecs_match(&c13.parent_idxs, &Vec::from([p1.file_order])));
+      assert!(p2.parent_idxs.is_empty());
+      assert!(vecs_match(&c21.parent_idxs, &Vec::from([p2.file_order])));
+    }
+  }
+
+    #[test]
+  fn test_encoded_parsing() {
+    let node_res = parse_file(DATA_DIR.join("03_basic_encoding.md"));
+    assert!(node_res.is_ok());
+  }
+}
+
+}

--- a/src-tauri/src/mdt/structs.rs
+++ b/src-tauri/src/mdt/structs.rs
@@ -3,6 +3,37 @@ pub mod structs {
 use serde::{Serialize, Deserialize};
 use specta::Type;
 
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::str::FromStr;
+
+// For non-const statics
+lazy_static! {
+  // TODO - Allow single char of node type followed by an optional amount of numbers or more node types
+  // - Maybe used to create Pro / Con pairs tracing to multiple nodes (will need unique IDs)
+  pub static ref VALID_NODE_TYPE: Regex = Regex::new(r"^[DOPCN\d]+$").unwrap(); 
+}
+
+// TODO - may be able to leverage complex enums to do a combo Pro Con tracing to multiple nodes?
+#[derive(Serialize, Deserialize, Type)]
+pub enum NodeType { 
+  Decision, Option,
+  Pro, Con,
+  Note
+}
+
+impl FromStr for NodeType {
+  type Err = (); //< required for FromStr
+  fn from_str(input: &str) -> Result<NodeType, Self::Err> {
+    match input {
+        "D" => Ok(NodeType::Decision), "O" => Ok(NodeType::Option),
+        "P" => Ok(NodeType::Pro), "C" => Ok(NodeType::Con),
+        "N" => Ok(NodeType::Note),
+        _ => Err(()),
+    }
+  }
+}
+
 #[derive(Default, Serialize, Deserialize, Type)]
 pub struct Node {
   pub text: String,
@@ -10,11 +41,12 @@ pub struct Node {
   pub file_order: u32, //< To ensure re-written file is in original order
   pub level: u32, //< Level to know how many spaces to re-write since left stripped before serializing
   pub parent_idxs: Vec<u32>,
+  pub type_is: Option<NodeType> //< `type` is reserved, so type_is should read well...
 }
 
 #[derive(Default, Serialize, Deserialize, Type)]
 pub struct Nodes {
-  pub title: String,
+  pub title: String, //< Markdowns top title - used to re-write later
   pub nodes: Vec<Node>
 }
 

--- a/src-tauri/test/data/03_basic_encoding.md
+++ b/src-tauri/test/data/03_basic_encoding.md
@@ -1,0 +1,16 @@
+# Bullets (md-decision-trees)
+
+D: What to do about X?
+* O: Could do Y
+  * P: Would help now
+  * C: Restricts interface
+* O: Could do Z
+  * P: Would help later
+  * C: Takes longer to implement
+    * N: Not a big deal - have plenty of time this sprint
+  * C: Requires more user knowledge
+
+D: What about the other thing?
+* O: This way
+* O: That way
+* N: Need to have meeting about this

--- a/ui/bindings/bindings.ts
+++ b/ui/bindings/bindings.ts
@@ -19,4 +19,5 @@ export function sendNodes(nodes: Nodes, filePath: string) {
 }
 
 export type Nodes = { title: string; nodes: Node[] }
-export type Node = { text: string; file_order: number; level: number; parent_idxs: number[] }
+export type Node = { text: string; file_order: number; level: number; parent_idxs: number[]; type_is: NodeType | null }
+export type NodeType = "Decision" | "Option" | "Pro" | "Con" | "Note"

--- a/ui/canvas/Canvas.tsx
+++ b/ui/canvas/Canvas.tsx
@@ -27,8 +27,10 @@ const NodeEditTextBox = forwardRef<NodeEditTextBoxMethods>((_, ref) => {
     setText(newText);
     setBox(box);
     setVisibleState(true); 
-    console.log(newText.length)
-    notNull(htmlRef.current).setSelectionRange(newText.length, newText.length); //< Put cursor at end - TODO, fix?
+    // Set value here to enable putting the cursor at the end
+    let html = notNull(htmlRef.current);
+    html.value = newText;
+    html.setSelectionRange(newText.length, newText.length);
   }
   const setVisibility = (visible: boolean) => { setVisibleState(visible); }
   const getText = (): string => { return text; }


### PR DESCRIPTION
Change naming of "Branch" to "Option"  
Add Rust parsing node type  
Extract BulletParser to own File  
Bugfix the node text edit cursor not going to the end of the node