### PR TITLE
Implement Node Creation

### DIFF
--- a/ui/canvas/key_handlers/NodeCreator.ts
+++ b/ui/canvas/key_handlers/NodeCreator.ts
@@ -14,7 +14,7 @@ export class NodeCreator {
   canvas: Canvas | null;
   render: Renderer | null;
 
-  handleKeyboardShortcuts(event: any) {
+  handleKeyboardShortcuts(event: KeyboardEvent) {
     if (event.ctrlKey) {
       if (event.key === 'c') {
         this.state = State.ReadyToCreate;
@@ -23,6 +23,7 @@ export class NodeCreator {
       this.state = State.None;
       let typeStr = this.getNodeTypeStringFromPressedKey(event.key)
       if (typeStr) { this.createNodeOnSelected(typeStr); }
+      event.preventDefault(); //< Stops key from entering node text on creation
     }
   }
 
@@ -33,7 +34,7 @@ export class NodeCreator {
     let newNode = notNull(renderer.createNode(optParentNode, type as fromRust.NodeType));
     renderer.focusOnNode(newNode.cyNode);
     renderer.onNodeSelect(newNode.cyNode);
-    this.canvas?.editSelectedNode();
+    this.canvas?.editSelectedNode(""); //< Clear placeholder text used to give node initial size
   }
 
   getNodeTypeStringFromPressedKey(key: String): String | null {


### PR DESCRIPTION
Allows creating top level Decision nodes, as well as child nodes for parents (after type is validated).
Focuses on the new node to allow user to type initial value.

Part of this simplifies the node render / get logic to make `nodeID` independent of `file_order` to avoid needing to update other nodes `file_order` as new nodes are inserted. Then, DFS in `getNodes` will properly populate the `file_order` at the end.

Also refactors dealing with `SelectNode` to allow the above `nodeID` addition.