### PR TITLE
Shortcuts to Switch Selected Node

### DIFF
--- a/ui/canvas/NodeTraveseral.ts
+++ b/ui/canvas/NodeTraveseral.ts
@@ -1,0 +1,81 @@
+import * as fromRust from "../bindings/bindings"
+import {Renderer} from "./Render"
+import {notNull} from "../Utils"
+
+// Had to make this since couldn't figure out why the built-in dfs was going top / right / left
+export class DFS {
+  visitedNodes: fromRust.Node[] = []
+  constructor(rootNodes: cytoscape.NodeCollection) {
+    rootNodes.forEach((node: cytoscape.NodeSingular) => this.continueDFS(node));
+  }
+  continueDFS(currNode: cytoscape.NodeSingular) {
+    this.visitedNodes.push(currNode.data().nodeData.dataNode);
+    currNode.outgoers().forEach((edge: cytoscape.EdgeSingular) => {
+      edge.targets().forEach((child: cytoscape.NodeSingular) => {
+        this.continueDFS(child)
+      });
+    });
+  }
+};
+
+// Keeps a window of nodes that allows switching the "currently selected node"  
+export class NodeTraverseSelection {
+  curr: cytoscape.NodeSingular;
+  firstParent: cytoscape.NodeSingular | null = null
+  rightSibs: cytoscape.NodeSingular[] = []
+  leftSibs: cytoscape.NodeSingular[] = []
+  renderer?: Renderer;
+
+  constructor(renderer: Renderer, startingNode: cytoscape.NodeSingular) {
+    this.renderer = renderer;
+    this.curr = startingNode;
+    this.populateFrom(startingNode);
+  }
+
+  moveDown() {
+    const firstChild = this.curr.outgoers()?.first()?.targets()?.first();
+    this.populateFrom(firstChild);
+  }
+
+  moveUp() {
+    this.populateFrom(this.firstParent);
+  }
+
+  moveRight() {
+    if (this.rightSibs.length == 0) { return; }
+    this.populateFrom(notNull(this.rightSibs.shift()));
+  }
+
+  moveLeft() {
+    if (this.leftSibs.length == 0) { return; }
+    this.populateFrom(notNull(this.leftSibs.shift()));
+  }
+ 
+  // Populates member variables starting from startingNode to be used for switching which node is selected
+  populateFrom(startingNode: cytoscape.NodeSingular | null) {
+    if (!startingNode || startingNode.length == 0) { return; }
+    this.curr.unselect();
+    this.curr = startingNode;
+    this.firstParent = this.curr.incomers()?.first()?.source()?.first();
+    // Get the siblings - handle if its a root or if it has actual siblings
+    let sibs = !this.firstParent ? notNull(this.renderer).cy.nodes().roots() : [];
+    if (this.firstParent) {
+      this.firstParent?.outgoers()?.forEach((edge: cytoscape.EdgeSingular) => {
+        edge.targets().forEach((sibOrSelf: cytoscape.NodeSingular) => {
+         sibs.push(sibOrSelf);
+      })});
+    }
+    // Separate the siblings between left and right
+    let gettingLeftSibs = true;
+    this.leftSibs = [], this.rightSibs = [];
+    sibs?.forEach((sibOrSelf: cytoscape.NodeSingular) => {
+      if (gettingLeftSibs && sibOrSelf.data().id === this.curr?.data().id) {;
+        gettingLeftSibs = false;
+        return;
+      }
+      let correctSideSibs = gettingLeftSibs ? this.leftSibs : this.rightSibs;
+      correctSideSibs.push(sibOrSelf);
+    });
+    this.curr.select();
+  }
+}

--- a/ui/canvas/key_handlers/NodeCreator.ts
+++ b/ui/canvas/key_handlers/NodeCreator.ts
@@ -34,7 +34,7 @@ export class NodeCreator {
     let newNode = notNull(renderer.createNode(optParentNode, type as fromRust.NodeType));
     renderer.focusOnNode(newNode.cyNode);
     renderer.onNodeSelect(newNode.cyNode);
-    this.canvas?.editSelectedNode(""); //< Clear placeholder text used to give node initial size
+    this.canvas?.editSelectedNode("");
   }
 
   getNodeTypeStringFromPressedKey(key: String): String | null {

--- a/ui/canvas/key_handlers/NodeSelector.ts
+++ b/ui/canvas/key_handlers/NodeSelector.ts
@@ -1,0 +1,56 @@
+import * as fromRust from "../../bindings/bindings"
+import {RenderBox, Renderer} from "../Render"
+import {NodeTraverseSelection} from "../NodeTraveseral"
+import {notNull} from "../../Utils"
+
+// Passes information needed for selected node
+export class SelectedNode {
+  node: fromRust.Node | null = null
+  renderID: string = ""
+  box: RenderBox | null = null
+  beingEdited: boolean = false
+}
+
+// Handles selecting nodes & traversing through them with keyboard shortcuts
+export class NodeSelector {
+  selectedNode: SelectedNode | null = null;
+  nodeSelector: NodeTraverseSelection | null = null;
+  renderer?: Renderer;
+
+  setSelectedNode(newNode: SelectedNode | null) { 
+    this.selectedNode = newNode;
+    if (!newNode) { this.nodeSelector = null; }
+  }
+
+  current(): SelectedNode | null { 
+    return this.selectedNode; 
+  }
+
+  constructor(renderer: Renderer) {
+    this.renderer = renderer;
+    document.addEventListener('keydown', (event) => this.handleKeyboardShortcuts(event));
+  }
+
+  handleKeyboardShortcuts(event: KeyboardEvent) {
+    if (event.ctrlKey) { return; }
+    if (event.key != 'j' && event.key != 'k' && event.key != 'h' && event.key != 'l') { return; }
+    event.preventDefault();
+    if (!this.nodeSelector) {
+      this.nodeSelector = notNull(this.renderer?.newNodeTraverseSelection(this.selectedNode));
+      if (!this.selectedNode) { return; } /* Start at first node instead of going that direction immediately */
+    }
+    if (event.key === 'j') {
+      this.nodeSelector?.moveDown();
+    } else if (event.key === 'k') {
+      this.nodeSelector?.moveUp();
+    } else if (event.key === 'h') {
+      this.nodeSelector?.moveLeft();
+    } else if (event.key === 'l') {
+      this.nodeSelector?.moveRight();
+    }
+    const maybeNewNode = this?.nodeSelector?.curr;
+    if (maybeNewNode?.id() != this.selectedNode?.renderID) {
+      this?.renderer?.onNodeSelect(notNull(maybeNewNode));
+    }
+  }
+}


### PR DESCRIPTION
Use keyboard shortcuts h j k l to move between selected nodes.
To do this, a new class `NodeSelector` was created & all of its relevant logic was moved from Canvas.
Then, it leveraged another new class `NodeTraversalSelection` to move around the graph.