### PR TITLE
Enable Creating New File. Increase responsiveness at the cost of CPU.

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "dialog-open"] }
+tauri = { version = "1.5", features = [ "dialog-save", "dialog-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.4.0"

--- a/src-tauri/src/mdt/file_parse.rs
+++ b/src-tauri/src/mdt/file_parse.rs
@@ -10,6 +10,8 @@ use lazy_static::lazy_static;
 // TODO - preserve from original file or make configurable
 pub const NUM_SPACES_PER_LEVEL: u32 = 2;
 
+pub const REQUIRED_HEADER: &str = "(md-decision-trees)";
+
 // For non-const statics
 lazy_static! {
   pub static ref DATA_DIR: PathBuf = PathBuf::from(format!("{top_dir}/test/data", top_dir=env!("CARGO_MANIFEST_DIR")));
@@ -20,7 +22,6 @@ pub fn parse_file(file_path: PathBuf) -> Result<Nodes, Box<dyn Error>> {
   let bound_str = read_to_string(file_path)?;
   let mut lines = bound_str.lines();
 
-  const REQUIRED_HEADER: &str = "(md-decision-trees)";
   let first_line = lines.next().ok_or("File did not contain a first header line")?;
   if !first_line.contains(REQUIRED_HEADER) { Err(format!("First line did not contain {}", REQUIRED_HEADER))?  }
 

--- a/src-tauri/src/mdt/file_write.rs
+++ b/src-tauri/src/mdt/file_write.rs
@@ -1,7 +1,7 @@
 pub mod file_write {
 
 use super::structs::{Nodes, Node, to_node_start_string};
-use super::file_parse::NUM_SPACES_PER_LEVEL;
+use super::file_parse::{NUM_SPACES_PER_LEVEL, REQUIRED_HEADER};
 use std::path::PathBuf;
 use std::error::Error;
 use std::fs::File;
@@ -17,9 +17,16 @@ fn add_opt_node_type(prefix: &mut String, node: &Node) {
 }
   
 pub fn write_nodes_to_file(nodes: Nodes, file_path: PathBuf) -> Result<(), Box<dyn Error>> {
+  let decision_title = || -> String {
+    if !nodes.title.is_empty() { 
+      return nodes.title;
+    }
+    let file_stem = file_path.as_path().file_stem().unwrap().to_str().unwrap();
+    return String::from(format!("# {} {}", file_stem, REQUIRED_HEADER));
+  }();
   let file = File::create(file_path)?;
   let mut writer = BufWriter::new(file);
-  writer.write(nodes.title.as_bytes())?;
+  writer.write(decision_title.as_bytes())?;
 
   for node in nodes.nodes {
     writer.write(b"\n")?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,8 @@
       "all": false,
       "dialog": {
         "all": false,
-        "open": true
+        "open": true,
+        "save": true
       }
     },
     "bundle": {

--- a/ui/canvas/Canvas.tsx
+++ b/ui/canvas/Canvas.tsx
@@ -3,7 +3,7 @@ import {errorStore} from "../stores/ErrorStore"
 import {canvasStore} from "../stores/CanvasStore"
 import {CanvasElement, Node} from "./CanvasElems"
 import {NodeEditTextBox} from './NodeEditTextBox';
-import {Renderer, RenderBox} from "./Render"
+import {Renderer} from "./Render"
 import * as fromRust from "../bindings/bindings"
 import {notNull} from "../Utils"
 import {NodeCreator} from "./key-handlers/NodeCreator"

--- a/ui/canvas/Render.ts
+++ b/ui/canvas/Render.ts
@@ -94,6 +94,16 @@ export class Renderer {
     if (!resetView) { layoutArgs = {...layoutArgs, fit: false, centerGraph: false}; }
     this.cy.elements().layout(layoutArgs).run();
     if (resetView) { this.cy.fit(); /*this.cy.zoom(1);*/ }
+    // Tried messing with layoutArgs animate / animateDuration / animateFilter - also cy.stop(), but nothing other
+    //  that this helped with responsiveness. Oddly, this increases CPU (opposite of my goal), but does feel responsive.
+    this.throttleAnimation();
+  }
+
+  throttleAnimation() {
+    this.cy.delay(1000, () => {
+      this.cy.clearQueue();
+      this.throttleAnimation();
+    });
   }
 
   // Members


### PR DESCRIPTION
Button to create new files - not currently working right due to a bug concerning creating edges to nodes that "dont exist", but will fix in bugfix MR.

Noticed CPU was high & responsiveness felt poor - tried to slow down cy animations which helped responsiveness, but increased CPU somehow. Feels better though, so will resolve later.