### PR TITLE
Hack to throttle renderer. Change 'create' (ctrl+c) to 'make' (ctrl+m).

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Scroll - change the zoom level
 * h / l - left and right siblings & j / k - parents & children
 
 `esc` - Various exits - ex. to close the "Error Console" if it appears, clear selection, etc
-`ctrl+c <node type, like d o p c n>` - Create nodes of a certain type:
-* ex. `ctrl+c d` to create a decision, `ctrl+o` for an Option
+`ctrl+m <node type, like d o p c n>` - Make nodes of a certain type:
+* ex. `ctrl+m d` to create a Decision, `ctrl+m o` for an Option
 
 `ctrl+e` - Edit the selected node's text **then** press `ctrl+e` again to save the edit:
 * Can press `esc` or click elsewhere to cancel the text changes

--- a/ui/canvas/key-handlers/NodeCreator.ts
+++ b/ui/canvas/key-handlers/NodeCreator.ts
@@ -6,7 +6,7 @@ import * as fromRust from "../../bindings/bindings"
 
 enum State {
   None,
-  ReadyToCreate
+  ReadyToMake
 }
 
 // Handles creating nodes
@@ -23,26 +23,26 @@ export class NodeCreator {
   /// Return true if event has handled
   handleKeyEvent(event: KeyboardEvent): boolean {
     if (event.ctrlKey) {
-      if (event.key === 'c') {
-        this.state = State.ReadyToCreate;
+      if (event.key === 'm') {
+        this.state = State.ReadyToMake;
         return true;
       }
-    } else if (this.state == State.ReadyToCreate) {
+    } else if (this.state == State.ReadyToMake) {
       this.state = State.None;
-      this.createNodeOnSelected(this.getNodeTypeStringFromPressedKey(event.key));
+      this.makeNodeOnSelected(this.getNodeTypeStringFromPressedKey(event.key));
       event.preventDefault(); //< Stops key from entering node text on creation & changing node size
       return true;
     }
     return false;
   }
 
-  createNodeOnSelected(type: String | null ) {
+  makeNodeOnSelected(type: String | null ) {
     if (!type) { return; }
     let optParentNode = this?.canvas?.getSelectedNode();
     let optParentNodeType = optParentNode?.node.type_is;
-    if (!this.canCreateTypeOnParent(optParentNodeType, type)) { 
+    if (!this.canMakeTypeOnParent(optParentNodeType, type)) { 
       const parentTypeStr = optParentNodeType ? optParentNodeType : "none";
-      errorStore.addError(`Cannot create node type '${type}' on parent node type '${parentTypeStr}'`);
+      errorStore.addError(`Cannot make node type '${type}' on parent node type '${parentTypeStr}'`);
       return;
     }
     let renderer = notNull(this.render);
@@ -62,7 +62,7 @@ export class NodeCreator {
     return null;
   }
 
-  canCreateTypeOnParent(parentType: String | undefined | null, newType: String): Boolean {
+  canMakeTypeOnParent(parentType: String | undefined | null, newType: String): Boolean {
     if (newType == "Note") { return true; }
     if (!parentType) { return newType == "Decision"; }
     if (parentType == "Decision") { return newType == "Option"; }


### PR DESCRIPTION
Previously, `htop` was showing an idle rendered graph was using 40% CPU in my VM - this change reduces it to 5%.
Also, to avoid hitting `ctrl+c` which caused a "bing" sound in my VM (due to SIGINT), change `create` to `make`:
* `ctrl+m <node type, like d o p c>` instead of `ctrl+c <node type>`

## High CPU Work Around
Using the profiling tools, the app seemed to be spending a lot of time in `cytoscapes` animation loop kicked off by `requestAnimationFrame`.  

At first, figured this was the re-rendering of the `Canvas` React component that owned the `canvas` HTML element that served as the  `cytoscape` container, but that did not seem to be the case (using `console.log`).

There did not seem to be a way to properly throttle `requestAnimationFrame`, so had to hack around to override this function for `window`, then when it was time, rebind the function to run once, then rebind back to the throttled version.
* This is definitely not the correct way, as I believe it is spinning a bit in this function, but it does a reduce the CPU greatly