### PR TITLE
Fix view resetting with some interactions. More shortcuts for view adjustments.

### DIFF
--- a/ui/App.css
+++ b/ui/App.css
@@ -10,5 +10,6 @@
   display: flex;
   flex-direction: row;
   width: 100%;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
 }

--- a/ui/canvas/Canvas.css
+++ b/ui/canvas/Canvas.css
@@ -1,10 +1,10 @@
 .canvas {
-  float: right;
-  width: 100%;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
+  position: relative;
   overflow: hidden;
   cursor: grab;
-  background-color: lightgrey
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 :root {

--- a/ui/canvas/Canvas.tsx
+++ b/ui/canvas/Canvas.tsx
@@ -17,6 +17,7 @@ export class Canvas extends React.Component {
   renderer: Renderer = new Renderer( (node: SelectedNode) => {this?.nodeSelector?.setSelectedNode(node);});
   nodeCreator: NodeCreator = new NodeCreator(this, this.renderer);
   nodeSelector: NodeSelector = new NodeSelector(this.renderer);
+  lastKey: string = '';
   getSelectedNode() : SelectedNode | null | undefined { return this?.nodeSelector?.current(); }
 
   // Mouse / keyboard Events
@@ -26,10 +27,30 @@ export class Canvas extends React.Component {
     const editKeyPressed : boolean = (event.ctrlKey && event.key === 'e');
     if (this.handleNodeTextEdit(editKeyPressed, escPressed)) { return; } //< If editing, ensure text keys are not used
     if (escPressed) { this.clearSelection(); }
+    // "zz" sequence - focus on selected node
+    if (!event.ctrlKey && event.key === 'z') {
+      if (this.lastKey === 'z' && this.getSelectedNode()) {
+        this.renderer?.focusNode?.(notNull(this.getSelectedNode()).renderID);
+        this.lastKey = '';
+        return;
+      }
+      this.lastKey = 'z';
+      return;
+    }
+    this.lastKey = event.key;
     if (this?.nodeCreator?.handleKeyEvent(event) || this?.nodeSelector?.handleKeyEvent(event)) { return; }
     if (event.ctrlKey) {
       if (event.key === 'z') {
         this.renderer?.doLayout();
+      } else if (event.key === '=' || event.key === '+') {
+        event.preventDefault();
+        this.renderer?.zoomIn?.();
+      } else if (event.key === '-') {
+        event.preventDefault();
+        this.renderer?.zoomOut?.();
+      } else if (event.key === '0') {
+        event.preventDefault();
+        this.renderer?.fitView?.();
       } else if (event.key === 'd' && this.getSelectedNode()) {
         this.renderer?.removeNode(notNull(this.getSelectedNode()).renderID);
       } else if (event.key === 's') {
@@ -95,8 +116,8 @@ export class Canvas extends React.Component {
   }
 
   render() {
-    return <>
+    return <div className="canvas">
       <RendererComp renderer={this.renderer}/>
-    </>
+    </div>
   }
 }

--- a/ui/modals/KeyboardHelp.tsx
+++ b/ui/modals/KeyboardHelp.tsx
@@ -92,6 +92,11 @@ export const KeyboardHelp: React.FC<KeyboardHelpProps> = ({ onClose }) => {
         { keyText: "h", description: "Right" },
         { keyText: "l", description: "Left" },
     ]},
+    { title: "View:", shortcuts: [
+        { keyText: "zz", description: "Center on selected node" },
+        { keyText: "Ctrl + 0", description: "Fit to view" },
+        { keyText: "Ctrl + (+/=)/(-)", description: "Zoom in/out" },
+    ]},
     { title: "Mouse", shortcuts: [
         { keyText: "right click node", description: "Node options - ex. change relationships" },
         { keyText: "scroll", description: "Zoom in/out" },


### PR DESCRIPTION
Small bugfixes:
- View was resetting when moving around node selection
- Canvas would sometimes not scale, and could not pan around

Small features:
- New shortcuts to adjust view / zoom-to-fit / focus on selected node